### PR TITLE
WIP [Issue #37]: Fix Build Failure: Lombok Missing Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,13 @@
 			<artifactId>zerocode-tdd</artifactId>
 			<version>${zerocode-tdd.version}</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.34</version>
+			<scope>provided</scope>
+		</dependency>
 		<!--
 		The below "micro-simulator" dependency is not needed for real projects.
 		This is present here just to mock/stub some end points for demo purpose only.


### PR DESCRIPTION
This PR addresses issue #37, where the build fails on Windows due to the inability to delete the `your_app_tests_logs.log` file during the `mvn clean install` process. The error is resolved by adding a necessary Lombok dependency in the `pom.xml`.

### Changes Made:
- Added Lombok dependency (`org.projectlombok:lombok:1.18.34`) with provided scope to `pom.xml`.

### Outcome:
- After adding the Lombok dependency, the build completes successfully without encountering the file deletion error.
  
### Additional Notes:
- Similar changes may be needed for Gradle projects as well.
  
Please review and merge this fix to resolve the build issue on Windows.
