### PR TITLE
Set up CI build with Maven and Gradle

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,0 +1,26 @@
+name: Gradle Build
+
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'adopt'
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew clean build
+

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,0 +1,24 @@
+name: Maven Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'adopt'
+    - name: Build with Maven
+      run: mvn clean test


### PR DESCRIPTION
### [Issue #39] Set up CI build with Maven and Gradle 

Methodology: 

- We'll create two separate workflow files in the .github/workflows directory.
- Add GitHub Actions workflow for Maven build (maven-build.yml)
- Add GitHub Actions workflow for Gradle build (gradle-build.yml)