### PR TITLE
Fix Gradle Build Failure by Updating Zerocode Dependency Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     compile group: 'junit', name: 'junit', version:'4.12'
     compile group: 'org.jsmart', name: 'micro-simulator', version:'1.1.8'
-    compile group: 'org.jsmart', name: 'zerocode-tdd', version: '1.3.6'
+    compile group: 'org.jsmart', name: 'zerocode-tdd', version: '1.3.43'
     testCompile group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.4.1'
     testCompile group: 'org.junit.vintage', name: 'junit-vintage-engine', version: '5.4.1'
 }


### PR DESCRIPTION
@authorjapps 

**Issue**: The Gradle build was failing due to a configuration issue with the version of Zerocode in build.gradle.

**Fix**: Updated the Zerocode dependency to the correct version to resolve the build failure. (1.3.6 --> 1.3.43)

**Additional Notes**: Tested the build after the change to ensure successful execution in GitHub Actions. This PR addresses the failure linked to issue [Set up CI build with Maven and Gradle #39](https://github.com/authorjapps/zerocode-hello-world/issues/39).